### PR TITLE
attempt to fix integration tests in CI

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -29,29 +29,28 @@ jobs:
       - name: Stop containers
         run: npm stop
 
-# FIXME: Enable these once integration tests exit cleanly.
-  # integration-tests:
-  #   name: Integration tests
-  #   runs-on: ubuntu-latest
-  #   needs: build
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v2
-  #     - name: Download artifact
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: hybridilusmu
-  #         path: /tmp
-  #     - name: Load image
-  #       run: |
-  #         docker load --input /tmp/hybridilusmu.tar
-  #         docker image ls -a
-  #     - run: touch .env.development
-  #     - name: Start containers
-  #       run: docker compose -f compose.yaml -f compose-ci.yaml up -d
-  #     - name: Run integration tests
-  #       run: npm run test:integration
-  #     - name: Stop containers
-  #       run: npm stop
+  integration-tests:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: hybridilusmu
+          path: /tmp
+      - name: Load image
+        run: |
+          docker load --input /tmp/hybridilusmu.tar
+          docker image ls -a
+      - run: touch .env.development
+      - name: Start containers
+        run: docker compose -f compose.yaml -f compose-ci.yaml up -d
+      - name: Run integration tests
+        run: npm run test:integration
+      - name: Stop containers
+        run: npm stop

--- a/app/package.json
+++ b/app/package.json
@@ -1,9 +1,9 @@
 {
   "name": "hybridilusmu",
   "version": "1.0.0",
-  "engines" : { 
-    "npm" : ">=9.5.1",
-    "node" : ">=18.16.0"
+  "engines": {
+    "npm": ">=9.5.1",
+    "node": ">=18.16.0"
   },
   "eslintConfig": {
     "extends": "./dev/.eslintrc.js"
@@ -14,7 +14,7 @@
     "watch": "npm run migrate && nodemon src/index.js",
     "migrate": "npx sequelize-cli db:migrate",
     "test": "mocha",
-    "test:integration": "mocha 'test/integration/*.js'",
+    "test:integration": "mocha 'test/integration/*.js' --exit",
     "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "setup-e2e": "pip3 install --upgrade --target ./test/e2e/testcases/site-packages/ --requirement ./test/e2e/requirements.txt",
     "eslint": "npx eslint ."


### PR DESCRIPTION
resolves #41 

Mocha 4.0 version disabled the --exit flag by default, which leaves some tests hanging if there is a database connection still open. In our case the database connection is made before the tests are run and it's closed independently from the tests, so I don't see an issue with adding the --exit flag back.