### PR TITLE
CI: Run checks for merge groups

### DIFF
--- a/.github/workflows/push_other_branches.yaml
+++ b/.github/workflows/push_other_branches.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - main
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
This should be enough to support GH's new merge queue functionality, i.e., check are now run for automatically created merge group (branches).